### PR TITLE
v2.1.0: modernize, fix BufferedRadnomProvider typo, upgrade test stack, add CI/CD

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.yml text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release --logger "trx;LogFileName=results.trx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: '8.x'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: '8.x'
 
@@ -31,7 +31,7 @@ jobs:
         run: dotnet pack --no-build -c Release -o ./nupkg
 
       - name: Login to NuGet
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
         with:
           usernameVar: NUGET_USER
           passwordVar: NUGET_TOKEN

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release
+
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o ./nupkg
+
+      - name: Login to NuGet
+        uses: NuGet/login@v1
+        with:
+          usernameVar: NUGET_USER
+          passwordVar: NUGET_TOKEN
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ env.NUGET_TOKEN }} --skip-duplicate

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,65 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.x'
+
+      - name: Setup Java (Sonar scanner requirement)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install sonar scanner and coverage tool
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Begin Sonar analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin \
+            /k:"PFalkowski_StrongRandom" \
+            /o:"pfalkowski" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
+            /d:sonar.exclusions="**/*.Test/**,**/*Test.cs"
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Collect coverage
+        run: dotnet-coverage collect "dotnet test --no-build -c Release" -f xml -o coverage.xml
+
+      - name: End Sonar analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,12 +43,12 @@ jobs:
       - name: Begin Sonar analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: $SONAR_TOKEN
         run: |
           dotnet-sonarscanner begin \
             /k:"PFalkowski_StrongRandom" \
             /o:"pfalkowski" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
             /d:sonar.exclusions="**/*.Test/**,**/*Test.cs"
@@ -61,5 +61,5 @@ jobs:
 
       - name: End Sonar analysis
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          SONAR_TOKEN: $SONAR_TOKEN
+        run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Begin Sonar analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: $SONAR_TOKEN
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           dotnet-sonarscanner begin \
             /k:"PFalkowski_StrongRandom" \
@@ -61,5 +61,5 @@ jobs:
 
       - name: End Sonar analysis
         env:
-          SONAR_TOKEN: $SONAR_TOKEN
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,23 +10,23 @@ jobs:
   sonar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: '8.x'
 
       - name: Setup Java (Sonar scanner requirement)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/Extensions.Standard.Randomization.Test/BufferedRandomProviderTest.cs
+++ b/Extensions.Standard.Randomization.Test/BufferedRandomProviderTest.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Extensions.Standard.Randomization.Test
 {
-    public class BufferedRadnomProviderTest
+    public class BufferedRandomProviderTest
     {
         [Theory]
         [InlineData(1)]

--- a/Extensions.Standard.Randomization.Test/Extensions.Standard.Randomization.Test.csproj
+++ b/Extensions.Standard.Randomization.Test/Extensions.Standard.Randomization.Test.csproj
@@ -1,22 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Extensions.Standard.Randomization\Extensions.Standard.Randomization.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/Extensions.Standard.Randomization.Test/StrongRandomTest.cs
+++ b/Extensions.Standard.Randomization.Test/StrongRandomTest.cs
@@ -221,8 +221,8 @@ namespace Extensions.Standard.Randomization.Test
         {
             var providerMock = new RandomProviderMock(0);
             var tested = new StrongRandom(providerMock);
-            byte[] nullBytesArray = null;
-            Assert.Throws<ArgumentNullException>(() => tested.NextBytes(nullBytesArray));
+            byte[]? nullBytesArray = null;
+            Assert.Throws<ArgumentNullException>(() => tested.NextBytes(nullBytesArray!));
         }
         [Fact]
         public void NextThrowsArgumentOutOfRangeExceptionWhenNegativeIntPassedIn()

--- a/Extensions.Standard.Randomization.Test/UtilitiesTest.cs
+++ b/Extensions.Standard.Randomization.Test/UtilitiesTest.cs
@@ -117,10 +117,8 @@ namespace Extensions.Standard.Randomization.Test
             }
         }
 
-        [Theory]
-        [InlineData("test")]
-        [InlineData(".NETStandard")]
-        public void NextAlphanumericRetrunsValidResult(string toChooseFrom)
+        [Fact]
+        public void NextAlphanumericRetrunsValidResult()
         {
             var randomSubstitute = Substitute.For<Random>();
             for (int i = '0'; i < '9' + 1; ++i)

--- a/Extensions.Standard.Randomization/BufferedRadnomProvider.cs
+++ b/Extensions.Standard.Randomization/BufferedRadnomProvider.cs
@@ -1,56 +1,12 @@
-﻿using System;
-using System.Security.Cryptography;
+using System;
 
 namespace Extensions.Standard.Randomization
 {
-    /// <summary>
-    /// Internally uses RNGCryptoServiceProvider. Buffered call to RNGCryptoServiceProvider up to bufferSize
-    /// </summary>
-    public class BufferedRandomProvider : IRandomProvider
+    /// <summary>Preserved for binary compatibility. Use <see cref="BufferedRandomProvider"/> instead (fixed spelling).</summary>
+    [Obsolete("Use BufferedRandomProvider instead (typo in original name fixed). This class will be removed in a future major version.")]
+    public sealed class BufferedRadnomProvider : BufferedRandomProvider
     {
-        public BufferedRandomProvider(int bufferSize)
-        {
-            _bufer = new Lazy<byte[]>(() => new byte[bufferSize], true);
-        }
-
-        private readonly Lazy<byte[]> _bufer;
-        private int _currentIndex;
-
-        private void GetBytesInternal(byte[] buffer)
-        {
-            using (var csprng = RandomNumberGenerator.Create())
-            {
-                csprng.GetBytes(buffer);
-            }
-        }
-
-        private void RefreshBuffer()
-        {
-            GetBytesInternal(_bufer.Value);
-            _currentIndex = 0;
-        }
-
-        public void GetBytes(byte[] input)
-        {
-            if (!_bufer.IsValueCreated)
-            {
-                RefreshBuffer();
-            }
-            if (input.Length > _bufer.Value.Length)
-            {
-                GetBytesInternal(input);
-                return;
-            }
-            else if (input.Length + _currentIndex > _bufer.Value.Length)
-            {
-                RefreshBuffer();
-            }
-
-            for (var i = 0; i < input.Length; ++i)
-            {
-                input[i] = _bufer.Value[i + _currentIndex];
-            }
-            _currentIndex += input.Length;
-        }
+        /// <inheritdoc/>
+        public BufferedRadnomProvider(int bufferSize) : base(bufferSize) { }
     }
 }

--- a/Extensions.Standard.Randomization/BufferedRandomProvider.cs
+++ b/Extensions.Standard.Randomization/BufferedRandomProvider.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Security.Cryptography;
+
+namespace Extensions.Standard.Randomization
+{
+    /// <summary>
+    /// Buffered wrapper around <see cref="RandomNumberGenerator"/> that amortises expensive CSPRNG calls
+    /// by filling an internal byte buffer in one shot and dispensing bytes from it on subsequent requests.
+    /// </summary>
+    public class BufferedRandomProvider : IRandomProvider
+    {
+        private readonly Lazy<byte[]> _buffer;
+        private int _currentIndex;
+
+        /// <param name="bufferSize">Number of random bytes to pre-fetch per CSPRNG call.</param>
+        public BufferedRandomProvider(int bufferSize)
+        {
+            _buffer = new Lazy<byte[]>(() => new byte[bufferSize], true);
+        }
+
+        private static void GetBytesInternal(byte[] buffer)
+        {
+            using var csprng = RandomNumberGenerator.Create();
+            csprng.GetBytes(buffer);
+        }
+
+        private void RefreshBuffer()
+        {
+            GetBytesInternal(_buffer.Value);
+            _currentIndex = 0;
+        }
+
+        /// <summary>Fills <paramref name="input"/> with cryptographically-strong random bytes.</summary>
+        public void GetBytes(byte[] input)
+        {
+            if (!_buffer.IsValueCreated)
+            {
+                RefreshBuffer();
+            }
+
+            if (input.Length > _buffer.Value.Length)
+            {
+                GetBytesInternal(input);
+                return;
+            }
+
+            if (input.Length + _currentIndex > _buffer.Value.Length)
+            {
+                RefreshBuffer();
+            }
+
+            for (var i = 0; i < input.Length; ++i)
+            {
+                input[i] = _buffer.Value[i + _currentIndex];
+            }
+            _currentIndex += input.Length;
+        }
+    }
+}

--- a/Extensions.Standard.Randomization/Extensions.Standard.Randomization.csproj
+++ b/Extensions.Standard.Randomization/Extensions.Standard.Randomization.csproj
@@ -5,34 +5,30 @@
     <RootNamespace>Extensions.Standard.Randomization</RootNamespace>
     <AssemblyName>Extensions.Standard.Randomization</AssemblyName>
     <Authors>Piotr Falkowski</Authors>
-    <Company></Company>
+    <Company>Piotr Falkowski</Company>
     <Product>StrongRandom</Product>
-    <Description>Random interface implemented with Cryptographically-Secure Pseudo-Random Number Generator. Everywhere you use System.Random, StrongRandom can be used now. Additionally missing boilerplate extensions for any Random: NextBool, NextChar, NextString etc. added.</Description>
-    <Copyright>Piotr Falkowski © 2018</Copyright>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <Description>System.Random drop-in backed by a Cryptographically-Secure Pseudo-Random Number Generator. Everywhere you use System.Random, StrongRandom can be used. Extension methods for any Random: NextBool, NextChar, NextByte, NextNormal and more.</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>Random, CSPRNG, Extension-methods</PackageTags>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageTags>Random, CSPRNG, Extension-methods, security, cryptography</PackageTags>
     <PackageProjectUrl>https://github.com/PFalkowski/StrongRandom</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StrongRandom</RepositoryUrl>
     <PackageId>StrongRandom</PackageId>
-    <Version>2.0.0</Version>
-    <PackageReleaseNotes>Update .NET Standard sdk to 2.0</PackageReleaseNotes>
+    <Version>2.1.0</Version>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Extensions.Standard.Randomization/StrongRandom.cs
+++ b/Extensions.Standard.Randomization/StrongRandom.cs
@@ -5,7 +5,7 @@ namespace Extensions.Standard.Randomization
     public class StrongRandom : Random
     {
         private readonly IRandomProvider _provider;
-        public StrongRandom(IRandomProvider provider = null)
+        public StrongRandom(IRandomProvider? provider = null)
         {
             _provider = provider ?? new BufferedRandomProvider(44);
         }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,116 @@
 # StrongRandom
 
-[![NuGet version (StrongRandom)](https://img.shields.io/nuget/v/StrongRandom.svg)](https://www.nuget.org/packages/StrongRandom/)
-[![Licence (StrongRandom)](https://img.shields.io/github/license/mashape/apistatus.svg)](https://choosealicense.com/licenses/mit/)
+[![CI](https://github.com/PFalkowski/StrongRandom/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/StrongRandom/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_StrongRandom&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_StrongRandom)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_StrongRandom&metric=coverage)](https://sonarcloud.io/summary/new_code?id=PFalkowski_StrongRandom)
+[![NuGet version](https://img.shields.io/nuget/v/StrongRandom.svg)](https://www.nuget.org/packages/StrongRandom/)
+[![NuGet downloads](https://img.shields.io/nuget/dt/StrongRandom.svg)](https://www.nuget.org/packages/StrongRandom/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/piotrfalkowski)
 
-```System.Random``` interface implemented with Cryptographically-Secure Pseudo-Random Number Generator. 
-Everywhere you use System.Random, StrongRandom can be used. 
+`System.Random` drop-in backed by a **Cryptographically-Secure Pseudo-Random Number Generator (CSPRNG)**. Everywhere you use `System.Random`, `StrongRandom` can be used instead. Also ships extension methods that add `NextBool`, `NextByte`, `NextChar`, `NextFloat`, `NextNormal` and more to _any_ `Random` instance.
 
-**Important!
-Use with caution in security critical scenarios, as the distribution can be somewhat skewed in integer returning method calls and NextDouble(). GetBytes() is direct call to underlying RNG provider and is safe.**
+> **Security note:** `NextBytes()` is a direct call to the underlying CSPRNG and is safe. Integer-returning methods (`Next`, `Next(max)`, `Next(min, max)`) and `NextDouble()` involve a transformation step that introduces a slight bias — do **not** rely on these for security-critical decisions such as key generation. Use `NextBytes()` for raw entropy.
 
-Extensions for any Random: NextBool, NextChar, NextString etc. added.
+## Installation
+
+```
+dotnet add package StrongRandom
+```
+
+## Quick start
+
+```csharp
+using Extensions.Standard.Randomization;
+
+// Drop-in: assign to a System.Random variable
+Random rng = new StrongRandom();
+
+int dice   = rng.Next(1, 7);          // 1–6
+double d   = rng.NextDouble();        // [0, 1)
+byte[] key = new byte[32];
+rng.NextBytes(key);                   // CSPRNG-safe raw bytes
+```
+
+## Extension methods (`Utilities`)
+
+All extensions target `System.Random`, so they work with `StrongRandom`, plain `new Random()`, or a mock.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `NextByte` | `(short upperLimit = 256)` | Random byte in `[0, upperLimit)` |
+| `NextBool` | `()` | `true` or `false` with equal probability |
+| `NextChar` | `(char lower = ' ', char upper = '\x7F')` | Random character in printable ASCII range |
+| `NextChar` | `(string chooseFrom)` | Random character from a specific set |
+| `NextLowercaseLetter` | `()` | Random letter `a`–`z` |
+| `NextUppercaseLetter` | `()` | Random letter `A`–`Z` |
+| `NextLetter` | `()` | Random letter `a`–`z` or `A`–`Z` |
+| `NextAlphanumeric` | `()` | Random digit, uppercase, or lowercase letter |
+| `NextFloat` | `()` | Random `float` in `[0, 1)` |
+| `NextFloat` | `(float min, float max)` | Random `float` in `[min, max)` |
+| `NextDouble` | `(double max)` | Random `double` in `[0, max)` |
+| `NextDouble` | `(double min, double max)` | Random `double` in `[min, max)` |
+| `NextNormal` | `(double mean, double sd = 1)` | Normally distributed value (Box-Muller) |
+
+```csharp
+var rng = new StrongRandom();
+
+bool coinFlip       = rng.NextBool();
+byte b              = rng.NextByte();
+char letter         = rng.NextLetter();
+char alphanumeric   = rng.NextAlphanumeric();
+float f             = rng.NextFloat(0f, 1f);
+double normal       = rng.NextNormal(mean: 0, sd: 1);
+char fromSet        = rng.NextChar("AEIOU");
+```
+
+## Customising the provider
+
+`StrongRandom` depends on `IRandomProvider` for its byte source. The default is `BufferedRandomProvider(44)`, which pre-fetches 44 bytes per CSPRNG call to reduce overhead.
+
+```csharp
+// Larger buffer — fewer round-trips to the CSPRNG
+var rng = new StrongRandom(new BufferedRandomProvider(256));
+
+// Custom provider (e.g. for testing)
+public class MyProvider : IRandomProvider
+{
+    public void GetBytes(byte[] input) { /* ... */ }
+}
+var testRng = new StrongRandom(new MyProvider());
+```
+
+## API
+
+### `StrongRandom`
+
+Inherits from `System.Random`. All `Random` members work as expected; randomness comes from the CSPRNG provider.
+
+| Member | Notes |
+|--------|-------|
+| `StrongRandom(IRandomProvider? provider = null)` | `null` uses `BufferedRandomProvider(44)` |
+| `Next()` | CSPRNG-backed |
+| `Next(int maxValue)` | CSPRNG-backed |
+| `Next(int minValue, int maxValue)` | CSPRNG-backed |
+| `NextDouble()` | CSPRNG-backed |
+| `NextBytes(byte[] buffer)` | Direct CSPRNG fill — unbiased |
+
+### `BufferedRandomProvider`
+
+| Member | Notes |
+|--------|-------|
+| `BufferedRandomProvider(int bufferSize)` | Pre-fetches `bufferSize` bytes per CSPRNG call |
+| `GetBytes(byte[] input)` | Fills `input` from the buffer, refreshing as needed |
+
+### `IRandomProvider`
+
+```csharp
+public interface IRandomProvider
+{
+    void GetBytes(byte[] input);
+}
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- **Phase 4 — naming bug fix:** `BufferedRadnomProvider` had a persistent typo ("Radom") in both the filename and class name. Added `BufferedRandomProvider` (correct spelling) as the canonical class; kept `BufferedRadnomProvider` as an `[Obsolete]` subclass shim pointing to the new name. File and test class renamed to match.
- **Phase 3 — csproj modernization:** removed dangling `Resources.resx`/`Resources.Designer.cs` references; added SourceLink 8.0.0, `LangVersion latest`, `Nullable enable`, `GenerateDocumentationFile`, `PackageReadmeFile`; removed deprecated `PackageLicenseUrl`/`GeneratePackageOnBuild`/stale `PackageReleaseNotes`; updated copyright; bumped to v2.1.0.
- **Test stack upgrade:** `netcoreapp2.0` → `net8.0`; NSubstitute 3.1.0 → 5.3.0; xunit 2.3.1 → 2.9.2; TestSdk 15.5.0 → 17.12.0; added `coverlet.collector`; fixed nullable warnings; fixed unused theory parameter.
- **Phase 6 — CI/CD:** added `ci.yml` (build + test on every push/PR), `publish.yml` (tag-driven OIDC Trusted Publishing — no long-lived NuGet key), `sonar.yml` (SonarCloud with coverage via dotnet-coverage).
- **README:** full rewrite — CI, SonarCloud quality gate + coverage, NuGet version + downloads, license, BMC badges; API reference table; usage examples; security note preserved.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 109/109 passed
- [ ] Merge → verify CI green
- [ ] One-time post-merge setup: set `NUGET_USER` repo variable; create NuGet Trusted Publishing policy; disable SonarCloud Automatic Analysis; add `SONAR_TOKEN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)